### PR TITLE
Issue #118 Fix identifier quoting

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/util/PostgreSqlUtils.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/util/PostgreSqlUtils.java
@@ -5,8 +5,10 @@ package de.bytefish.pgbulkinsert.util;
 import de.bytefish.pgbulkinsert.exceptions.PgConnectionException;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.postgresql.PGConnection;
+import org.postgresql.core.Utils;
 
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Optional;
 
 public final class PostgreSqlUtils {
@@ -44,10 +46,12 @@ public final class PostgreSqlUtils {
         return Optional.empty();
     }
 
-    public static final char QuoteChar = '"';
-
     public static String quoteIdentifier(String identifier) {
-        return requiresQuoting(identifier) ? (QuoteChar + identifier + QuoteChar) : identifier;
+        try {
+            return Utils.escapeIdentifier(null, identifier).toString();
+        } catch (SQLException e) {
+            throw new IllegalArgumentException("Invalid identifier", e);
+        }
     }
 
     @SuppressWarnings("NullAway")
@@ -62,17 +66,5 @@ public final class PostgreSqlUtils {
         }
 
         return String.format("%1$s.%2$s", schemaName, tableName);
-    }
-
-    private static boolean requiresQuoting(String identifier) {
-
-        char first = identifier.charAt(0);
-        char last = identifier.charAt(identifier.length() - 1);
-
-        if (first == QuoteChar && last == QuoteChar) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/util/PostgresUtilsTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/util/PostgresUtilsTest.java
@@ -15,10 +15,34 @@ public class PostgresUtilsTest {
     }
 
     @Test
-    public void testAlreadyQuotedIdentifier() {
-        final String identifier = "\"binary\"";
+    public void testOneDoubleQuote() {
+        final String identifier = "\"";
         final String result = PostgreSqlUtils.quoteIdentifier(identifier);
 
-        Assert.assertEquals("\"binary\"", result);
+        Assert.assertEquals("\"\"\"\"", result);
+    }
+
+    @Test
+    public void testTwoDoubleQuotes() {
+        final String identifier = "\"\"";
+        final String result = PostgreSqlUtils.quoteIdentifier(identifier);
+
+        Assert.assertEquals("\"\"\"\"\"\"", result);
+    }
+
+    @Test
+    public void testIdentifierWithQuotes() {
+        final String identifier = "\"x\"";
+        final String result = PostgreSqlUtils.quoteIdentifier(identifier);
+
+        Assert.assertEquals("\"\"\"x\"\"\"", result);
+    }
+
+    @Test
+    public void testIdentifierWithQuoteInTheMiddle() {
+        final String identifier = "x\"y";
+        final String result = PostgreSqlUtils.quoteIdentifier(identifier);
+
+        Assert.assertEquals("\"x\"\"y\"", result);
     }
 }


### PR DESCRIPTION
Use PgJDBC `Utils.escapeIdentifier()` function to do the quoting. Fixes #118.

This changes the functionality of the `quoteIdentifier()` function so that it doesn't treat identifiers starting and ending with a double quote as already quoted.