### PR TITLE
Add bulk merge feature

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkUpsert.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/PgBulkUpsert.java
@@ -1,0 +1,69 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.postgresql.PGConnection;
+
+import de.bytefish.pgbulkinsert.configuration.Configuration;
+import de.bytefish.pgbulkinsert.configuration.IConfiguration;
+import de.bytefish.pgbulkinsert.mapping.AbstractUpsertMapping;
+
+/**
+ * Bulk upsert class, to insert or update rows if it already exist
+ * 
+ * @author gderuette
+ * @param <TEntity>
+ */
+public class PgBulkUpsert<TEntity> implements IPgBulkInsert<TEntity> {
+	private final PgBulkInsert<TEntity> pgBulkInsert;
+	private final AbstractUpsertMapping<TEntity> mapping;
+
+	public PgBulkUpsert(AbstractUpsertMapping<TEntity> mapping) {
+		this(new Configuration(), mapping);
+	}
+
+	public PgBulkUpsert(IConfiguration configuration, AbstractUpsertMapping<TEntity> mapping) {
+		Objects.requireNonNull(configuration, "'configuration' has to be set");
+		Objects.requireNonNull(mapping, "'mapping' has to be set");
+		this.pgBulkInsert = new PgBulkInsert<>(configuration, mapping);
+		this.mapping = mapping;
+	}
+
+	/**
+	 * Bulk upsert entities : creates a temporary table, insert all values in it and
+	 * then try to copy from the temporary table to the target.
+	 */
+	public void saveAll(PGConnection pgConnection, Stream<TEntity> entities) throws SQLException {
+		try (Statement statement = ((Connection) pgConnection).createStatement()) {
+			String tempTableQuery = String.format("create table if not exists %s as select * from %s with no data;",
+					this.mapping.getTempTableName(), this.mapping.getTableName());
+			statement.execute(tempTableQuery);
+			pgBulkInsert.saveAll(pgConnection, entities);
+			StringBuilder insertQuery = new StringBuilder(String.format(
+					"insert into %s select * from %s on conflict (%s) do update ", this.mapping.getTableName(),
+					this.mapping.getTempTableName(), this.mapping.getPrimaryKey()));
+
+			String setColumns = this.mapping.getColumns().stream()
+					.map(column -> String.format(" %s = EXCLUDED.%s", column.getColumnName(), column.getColumnName()))
+					.collect(Collectors.joining(","));
+
+			insertQuery.append(" set ");
+			insertQuery.append(setColumns);
+			insertQuery.append(';');
+			statement.execute(insertQuery.toString());
+			statement.execute("drop table if exists " + this.mapping.getTempTableName());
+		}
+	}
+
+	public void saveAll(PGConnection connection, Collection<TEntity> entities) throws SQLException {
+		saveAll(connection, entities.stream());
+	}
+}

--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractUpsertMapping.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/mapping/AbstractUpsertMapping.java
@@ -1,0 +1,64 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.mapping;
+
+import de.bytefish.pgbulkinsert.pgsql.handlers.IValueHandlerProvider;
+import de.bytefish.pgbulkinsert.pgsql.handlers.ValueHandlerProvider;
+
+/**
+ * Mapping to use upsert
+ * 
+ * @author gderuette
+ * @param <E> mapped class
+ */
+public abstract class AbstractUpsertMapping<E> extends AbstractMapping<E> {
+
+	private static Long idx = 0l;
+	private final String primaryKey;
+	private final String tableName;
+
+	protected AbstractUpsertMapping(String schemaName, String tableName, String primaryKey) {
+		this(new ValueHandlerProvider(), schemaName, tableName, false, primaryKey);
+	}
+
+	protected AbstractUpsertMapping(String schemaName, String tableName, boolean usePostgresQuoting,
+			String primaryKey) {
+		this(new ValueHandlerProvider(), schemaName, tableName, usePostgresQuoting, primaryKey);
+	}
+
+	protected AbstractUpsertMapping(IValueHandlerProvider provider, String schemaName, String tableName,
+			boolean usePostgresQuoting, String primaryKey) {
+		super(provider, schemaName, tableName + "_temp_" + getNextIdx(), usePostgresQuoting);
+		this.primaryKey = primaryKey;
+		this.tableName = tableName;
+	}
+
+	/**
+	 * @return return current index for temp table. Used to prevent conflict on
+	 *         table name
+	 */
+	private static synchronized Long getNextIdx() {
+		return idx++;
+	}
+
+	/**
+	 * @return merge primary key
+	 */
+	public String getPrimaryKey() {
+		return this.primaryKey;
+	}
+
+	/**
+	 * @return target table name
+	 */
+	public String getTableName() {
+		return this.tableName;
+	}
+
+	/**
+	 * @return temporary table name
+	 */
+	public String getTempTableName() {
+		return this.table.getTableName();
+	}
+}

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/integration/IntegrationUpsertTest.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/integration/IntegrationUpsertTest.java
@@ -1,0 +1,87 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.test.integration;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import de.bytefish.pgbulkinsert.PgBulkUpsert;
+import de.bytefish.pgbulkinsert.test.mapping.PersonWithIdUpsertMapping;
+import de.bytefish.pgbulkinsert.test.model.PersonWithId;
+import de.bytefish.pgbulkinsert.test.utils.TransactionalTestBase;
+import de.bytefish.pgbulkinsert.util.PostgreSqlUtils;
+
+public class IntegrationUpsertTest extends TransactionalTestBase {
+
+	@Override
+	protected void onSetUpInTransaction() throws Exception {
+		createTable();
+	}
+
+	@Test
+	public void bulkInsertPersonDataTest() throws SQLException {
+		// Create a large list of People:
+		List<PersonWithId> personList = getPersonList(100000, "Philipp");
+		List<PersonWithId> personListUpdate = getPersonList(50000, "Johann");
+		// Create the BulkInserter:
+		PgBulkUpsert<PersonWithId> bulkupsert = new PgBulkUpsert<PersonWithId>(new PersonWithIdUpsertMapping(schema));
+		// Now save all entities of a given stream:
+		bulkupsert.saveAll(PostgreSqlUtils.getPGConnection(connection), personList.stream());
+		bulkupsert.saveAll(PostgreSqlUtils.getPGConnection(connection), personListUpdate.stream());
+		Assert.assertEquals(50000, getRowCountByName("Philipp"));
+		Assert.assertEquals(50000, getRowCountByName("Johann"));
+	}
+
+	private List<PersonWithId> getPersonList(int num, String firstName) {
+		List<PersonWithId> personList = new ArrayList<>();
+
+		for (long pos = 0; pos < num; pos++) {
+			PersonWithId p = new PersonWithId();
+
+			p.setId(pos);
+			p.setFirstName(firstName);
+			p.setBirthDate(LocalDate.of(1989, 4, 12));
+
+			personList.add(p);
+		}
+
+		return personList;
+	}
+
+	private boolean createTable() throws SQLException {
+
+		String sqlStatement = String.format("CREATE TABLE %s.unit_test\n", schema) //
+				+ "            (\n" //
+				+ "                id bigint,\n" //
+				+ "                first_name text,\n" //
+				+ "                last_name text,\n" //
+				+ "                birth_date date,\n" //
+				+ "                constraint pk_person primary key (id)\n" //
+				+ "            );";
+
+		Statement statement = connection.createStatement();
+
+		return statement.execute(sqlStatement);
+	}
+
+	private int getRowCountByName(String name) throws SQLException {
+
+		Statement s = connection.createStatement();
+
+		ResultSet r = s.executeQuery(
+				String.format("SELECT COUNT(*) AS rowcount FROM %s.unit_test where first_name='%s'", schema, name));
+		r.next();
+		int count = r.getInt("rowcount");
+		r.close();
+
+		return count;
+	}
+
+}

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/mapping/PersonWithIdUpsertMapping.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/mapping/PersonWithIdUpsertMapping.java
@@ -1,0 +1,17 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.test.mapping;
+
+import de.bytefish.pgbulkinsert.mapping.AbstractUpsertMapping;
+import de.bytefish.pgbulkinsert.test.model.PersonWithId;
+
+public class PersonWithIdUpsertMapping extends AbstractUpsertMapping<PersonWithId> {
+	public PersonWithIdUpsertMapping(String schema) {
+		super(schema, "unit_test", "id");
+
+		mapLongPrimitive("id", PersonWithId::getId);
+		mapText("first_name", PersonWithId::getFirstName);
+		mapText("last_name", PersonWithId::getLastName);
+		mapDate("birth_date", PersonWithId::getBirthDate);
+	}
+}

--- a/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/model/PersonWithId.java
+++ b/PgBulkInsert/src/test/java/de/bytefish/pgbulkinsert/test/model/PersonWithId.java
@@ -1,0 +1,62 @@
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+package de.bytefish.pgbulkinsert.test.model;
+
+import java.time.LocalDate;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class PersonWithId {
+
+	@Nullable
+	private long id;
+
+	@Nullable
+	private String firstName;
+
+	@Nullable
+	private String lastName;
+
+	@Nullable
+	private LocalDate birthDate;
+
+	public PersonWithId() {
+	}
+
+	@Nullable
+	public long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@Nullable
+	public String getFirstName() {
+		return firstName;
+	}
+
+	public void setFirstName(String firstName) {
+		this.firstName = firstName;
+	}
+
+	@Nullable
+	public String getLastName() {
+		return lastName;
+	}
+
+	public void setLastName(String lastName) {
+		this.lastName = lastName;
+	}
+
+	@Nullable
+	public LocalDate getBirthDate() {
+		return birthDate;
+	}
+
+	public void setBirthDate(LocalDate birthDate) {
+		this.birthDate = birthDate;
+	}
+
+}


### PR DESCRIPTION
Allow to bulk merge :

- Create new temporary table
- Copy data in this temporary table
- Upsert data from temporary table to target table
- Drop temporary table

To use bulk merge, you must define primary key in mapping (AbstractMergeMapping)