### PR TITLE
Remove explicit dependency on checkerframework.

### DIFF
--- a/PgBulkInsert/pom.xml
+++ b/PgBulkInsert/pom.xml
@@ -218,13 +218,6 @@
         </dependency>
 
         <dependency>
-            <scope>compile</scope>
-            <groupId>org.checkerframework</groupId>
-            <artifactId>checker-qual</artifactId>
-            <version>3.9.1</version>
-        </dependency>
-
-        <dependency>
             <scope>test</scope>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>


### PR DESCRIPTION
This PR removes the explicit dependency on checkerframework. The postgresql jdbc driver already pulls in a different version of checkerframework. Removing the explicit dependency in PgBulkInsert and relying on the version from postgresql jdbc driver avoids a version conflict.

The current version of PgBulkInsert pulls version 3.9.1 of checkerframework while postgresql pulls in version 3.5.0. https://mvnrepository.com/artifact/org.postgresql/postgresql/42.2.19