### PR TITLE
Correct scope

### DIFF
--- a/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRow.java
+++ b/PgBulkInsert/src/main/java/de/bytefish/pgbulkinsert/row/SimpleRow.java
@@ -160,11 +160,11 @@ public class SimpleRow {
         setValue(columnName, DataType.Interval, value);
     }
 
-    protected void setTime(String columnName, LocalTime value) {
+    public void setTime(String columnName, LocalTime value) {
         setValue(columnName, DataType.Time, value);
     }
 
-    protected void setTime(int ordinal, LocalTime value) {
+    public void setTime(int ordinal, LocalTime value) {
         setValue(ordinal, DataType.Time, value);
     }
 


### PR DESCRIPTION
The scope of the `setTime` methods was set too narrowly. This makes them `public`, like other setters in this class.